### PR TITLE
Error caused by invalid syntax in ACL $override feature

### DIFF
--- a/classes/s3.php
+++ b/classes/s3.php
@@ -150,7 +150,7 @@ class S3
 		$acl = self::$default_acl;
 
 		if ($override !== null && defined('self::'.$override))
-			$acl = self::$override;
+			$acl = $override;
 
 		if ($acl === null)
 			self::__triggerError('S3::getACL(): You must set a default ACL level in Fuel-S3 config.');


### PR DESCRIPTION
I was running into this via:

S3::putObject(S3::inputFile($file), $bucket, $name, 'ACL_PUBLIC_READ');

that made it along to getACL where $acl = self::$override; would throw an error like:
self::public-read not defined

This fixed it.

Signed-off-by: Ian Turgeon iturgeon@gmail.com
